### PR TITLE
ecl: push arm64 when aarch64, armv8l, armv8b or aarch64_be reported

### DIFF
--- a/src/tf-ecl.lisp
+++ b/src/tf-ecl.lisp
@@ -52,4 +52,5 @@
 #+x86_64 (pushnew :x86-64 *features*)
 #+(or i386 i486 i586 i686) (pushnew :x86 *features*)
 #+(or armv5l armv6l armv7l) (pushnew :arm *features*)
+#+(or aarch64 armv8l armv8b aarch64_be) (pushnew :arm64 *features*)
 #+mipsel (pushnew :mips *features*)


### PR DESCRIPTION
The arm64 arch have many names: aarch64, arm64 armv8l, armv8b or aarch64_be. But the usual are arm64 (push by apple) and aarch64 (push by almost all others). I add the others by precaution, maybe someone need theirs. 