### PR TITLE
Add 64-bit and 32-bit features

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,12 @@ something like `:PC386` in both cases or have an additional `:X86-32`. Or
 finally, have just `:X86`, `:PPC`, etc, and add `:32-BIT-CPU` and
 `:64-BIT-CPU` features.]
 
+### Register Size
+These features denote the size of a register on the CPU and are mutually exclusive.
+
+  - `:64-bit`
+  - `:32-bit`
+
 
 Unreferenced References
 -----------------------

--- a/src/tf-abcl.lisp
+++ b/src/tf-abcl.lisp
@@ -44,3 +44,6 @@
 ;;;; CPU
 
 ;;; ABCL already pushes :x86-64
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-allegro.lisp
+++ b/src/tf-allegro.lisp
@@ -47,3 +47,6 @@
 
 ;;; what about PPC64?
 #+powerpc (pushnew :ppc *features*)
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-clisp.lisp
+++ b/src/tf-clisp.lisp
@@ -70,3 +70,6 @@
   (when cpu
     (pushnew (intern (symbol-name cpu) '#:keyword)
              *features*)))
+
+#+word-size=64 (pushnew :64-bit *features*)
+#+word-size=32 (pushnew :32-bit *features*)

--- a/src/tf-cmucl.lisp
+++ b/src/tf-cmucl.lisp
@@ -42,3 +42,6 @@
 ;;;; CPU
 
 ;;; CMUCL already pushes :PPC and :X86.
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-corman.lisp
+++ b/src/tf-corman.lisp
@@ -37,3 +37,5 @@
 ;;;; CPU
 
 (pushnew :x86 *features*)
+;; Not sure about this, iiuc corman can run under 64bit windows...
+(pushnew :32-bit *features*)

--- a/src/tf-ecl.lisp
+++ b/src/tf-ecl.lisp
@@ -54,3 +54,5 @@
 #+(or armv5l armv6l armv7l) (pushnew :arm *features*)
 #+(or aarch64 armv8l armv8b aarch64_be) (pushnew :arm64 *features*)
 #+mipsel (pushnew :mips *features*)
+#+uint64-t (pushnew :64-bit *features*)
+#+(and uint32-t (not uint64-t)) (pushnew :32-bit *features*)

--- a/src/tf-lispworks.lisp
+++ b/src/tf-lispworks.lisp
@@ -56,3 +56,5 @@
 ;;; Lispworks already pushes :X86.
 
 #+powerpc (pushnew :ppc *features*)
+#+lispworks-64bit (pushnew :64-bit *features*)
+#+lispworks-32bit (pushnew :32-bit *features*)

--- a/src/tf-mcl.lisp
+++ b/src/tf-mcl.lisp
@@ -39,3 +39,6 @@
 ;;;; CPU
 
 #+ppc-target (pushnew :ppc *features*)
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-mezzano.lisp
+++ b/src/tf-mezzano.lisp
@@ -37,3 +37,4 @@
 ;;;; CPU
 
 ;;; Mezzano already pushes :X86-64.
+(pushnew :64-bit *features*)

--- a/src/tf-mkcl.lisp
+++ b/src/tf-mkcl.lisp
@@ -46,4 +46,6 @@
 ;;;; CPU
 
 ;;; MKCL conforms to SPEC
-
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-mocl.lisp
+++ b/src/tf-mocl.lisp
@@ -38,3 +38,6 @@
 ;;;; CPU
 
 ;;; MOCL already pushes :ARM.
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/src/tf-openmcl.lisp
+++ b/src/tf-openmcl.lisp
@@ -45,3 +45,6 @@
 ;;; what about ppc64?
 #+ppc-target (pushnew :ppc *features*)
 #+x8664-target (pushnew :x86-64 *features*)
+
+#+64-bit-host (pushnew :64-bit *features*)
+#+32-bit-host (pushnew :32-bit *features*)

--- a/src/tf-sbcl.lisp
+++ b/src/tf-sbcl.lisp
@@ -48,4 +48,4 @@
 
 ;;;; CPU
 
-;;; SBCL already pushes: :X86, :X86-64, and :PPC
+;;; SBCL already pushes: :X86, :X86-64, :PPC, :32-BIT, and :64-BIT

--- a/src/tf-scl.lisp
+++ b/src/tf-scl.lisp
@@ -45,3 +45,5 @@
 ;;; For 64 bit CPUs the SCL pushes: :64bit
 
 #+amd64 (pushnew :x86-64 *features*)
+#+64bit (pushnew :64-bit *features*)
+#-64bit (pushnew :32-bit *features*)

--- a/src/tf-xcl.lisp
+++ b/src/tf-xcl.lisp
@@ -37,3 +37,6 @@
 ;;;; CPU
 
 ;;; XCL already pushes :X86 and :X86-64.
+(if (< 32 (logcount most-positive-fixnum))
+    (pushnew :64-bit *features*)
+    (pushnew :32-bit *features*))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -124,6 +124,12 @@
              t)))
   t)
 
+(deftest cpu.3
+    (ecase (foreign-type-size :pointer)
+      (4 (featurep :32-bit))
+      (8 (featurep :64-bit)))
+  t)
+
 ;; regression test: sometimes, silly logic leads to pushing nil to
 ;; *features*.
 (deftest nil.1 (featurep nil) nil)


### PR DESCRIPTION
This should fix part of #12. It's possible more implementations have features that could be translated, but I could not install all of the ones listed here to see.

Clasp will push the feature natively soon.