### PR TITLE
Adds for normalizing to :sunos for Solaris targets.

### DIFF
--- a/src/tf-ecl.lisp
+++ b/src/tf-ecl.lisp
@@ -44,6 +44,7 @@
 
 #+darwin (pushnew :unix *features*)
 #+win32 (pushnew :windows *features*)
+#+sun4sol2 (pushnew :sunos *features*)
 
 ;;;; CPU
 

--- a/src/tf-lispworks.lisp
+++ b/src/tf-lispworks.lisp
@@ -51,6 +51,8 @@
 #+(or darwin freebsd netbsd openbsd)
 (pushnew :bsd *features*)
 
+#+solaris2 (pushnew :sunos *features*)
+
 ;;;; CPU
 
 ;;; Lispworks already pushes :X86.

--- a/src/tf-openmcl.lisp
+++ b/src/tf-openmcl.lisp
@@ -40,6 +40,8 @@
 
 #+darwin (pushnew :bsd *features*)
 
+#+solaris (pushnew :sunos *features*)
+
 ;;;; CPU
 
 ;;; what about ppc64?


### PR DESCRIPTION
SBCL uses :sunos, ccl uses :solaris, ecl uses :sun4sol2 and LispWorks
is :solaris2.