### PR TITLE
Added :32-bit feature for SBCL

### DIFF
--- a/src/tf-sbcl.lisp
+++ b/src/tf-sbcl.lisp
@@ -48,4 +48,5 @@
 
 ;;;; CPU
 
-;;; SBCL already pushes: :X86, :X86-64, :PPC, :32-BIT, and :64-BIT
+;;; SBCL already pushes: :X86, :X86-64, :PPC, and :64-BIT
+#-64-bit (pushnew :32-bit *features*)


### PR DESCRIPTION
Hello,

I noticed that :32-bit is not defined when using sbcl on a 32 bit cpu. I get the impression that at one point it existed though. The test run below shows that CPU.3 fails when running with sbcl on a 32 bit cpu. Thanks.

Doing 10 pending tests of 10 tests total.
 ENDIANNESS.1 OS.1 OS.2 OS.3 OS.4 CPU.1 CPU.2
Test CPU.3 failed
Form: (ECASE (FOREIGN-TYPE-SIZE :POINTER)
        (4 (FEATUREP :32-BIT))
        (8 (FEATUREP :64-BIT)))
Expected value: T
Actual value: NIL.
 NIL.1 NIL.2
1 out of 10 total tests failed: CPU.3.
NIL
