### PR TITLE
Add support for Genera

### DIFF
--- a/src/tf-genera.lisp
+++ b/src/tf-genera.lisp
@@ -1,0 +1,44 @@
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-Lisp;  Package: CL-USER; Base: 10; -*-
+;;;
+;;; tf-genera.lisp --- Genera trivial-features implementation.
+;;;
+;;; Copyright (C) 2007, Luis Oliveira  <loliveira@common-lisp.net>
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+(in-package :cl-user)
+
+;;; Endianness
+
+(pushnew :little-endian *features*)
+
+;;; Operating System
+
+;; #+Genera is already on *features*
+
+;;; CPU
+
+#+(or IMach VLM) (pushnew :Ivory *features*)
+;; #+3600 for L-machines is already on *features*
+
+;;; Register Size
+
+(pushnew :32-bit *features*)

--- a/trivial-features.asd
+++ b/trivial-features.asd
@@ -1,4 +1,5 @@
-;;;; -*- Mode: lisp; indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-Lisp; Package: ASDF; Base: 10; -*-
+;;;; The above modeline is required for Genera. Do not change.
 ;;;
 ;;; trivial-features.asd --- ASDF system definition.
 ;;;
@@ -24,7 +25,7 @@
 ;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ;;; DEALINGS IN THE SOFTWARE.
 
-#-(or sbcl clisp allegro openmcl mcl mkcl lispworks ecl cmu scl cormanlisp abcl xcl mocl clasp mezzano)
+#-(or sbcl clisp allegro openmcl mcl mkcl lispworks ecl cmu scl cormanlisp abcl xcl mocl clasp mezzano genera)
 (error "Sorry, your Lisp is not supported.  Patches welcome.")
 
 (defsystem trivial-features
@@ -40,6 +41,7 @@
      #+cmu        (:file "tf-cmucl")
      #+cormanlisp (:file "tf-cormanlisp")
      #+ecl        (:file "tf-ecl")
+     #+genera     (:file "tf-genera")
      #+lispworks  (:file "tf-lispworks")
      #+openmcl    (:file "tf-openmcl")
      #+mcl        (:file "tf-mcl")
@@ -53,7 +55,7 @@
      #+mezzano    (:file "tf-mezzano")
      ))))
 
-#-mezzano
+#-(or genera mezzano)
 (defmethod perform ((o test-op) (c (eql (find-system 'trivial-features))))
   (operate 'load-op 'trivial-features-tests)
   (operate 'test-op 'trivial-features-tests))


### PR DESCRIPTION
All Genera systems are #+little-endian and #+32-bit

Genera runs on Symbolics Lisp Machines and Symbolics Virtual Lisp Machines (VLM).
For Ivory based systems, including VLM, add #+Ivory. For older systems, use #+3600.