### PR TITLE
Fix detection of 32-bit feature on CLISP

### DIFF
--- a/src/tf-clisp.lisp
+++ b/src/tf-clisp.lisp
@@ -72,4 +72,4 @@
              *features*)))
 
 #+word-size=64 (pushnew :64-bit *features*)
-#+word-size=32 (pushnew :32-bit *features*)
+#-word-size=64 (pushnew :32-bit *features*)


### PR DESCRIPTION
The feature “word-size=32” is not pushed on 32-bit arches. Rather test for the absence of “word-size=64”.