### PR TITLE
Add dotcl (.NET/CLR) backend

### DIFF
--- a/trivial-features.asd
+++ b/trivial-features.asd
@@ -25,7 +25,7 @@
 ;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ;;; DEALINGS IN THE SOFTWARE.
 
-#-(or sbcl clisp allegro openmcl mcl mkcl lispworks ecl cmu scl cormanlisp abcl xcl mocl clasp mezzano genera)
+#-(or sbcl clisp allegro openmcl mcl mkcl lispworks ecl cmu scl cormanlisp abcl xcl mocl clasp mezzano genera dotcl)
 (error "Sorry, your Lisp is not supported.  Patches welcome.")
 
 (defsystem trivial-features


### PR DESCRIPTION
[dotcl](https://github.com/dotcl/dotcl) is Common Lisp on .NET: Lisp is compiled
to CIL and runs on the .NET JIT. It was absent from the supported-implementations
guard, so trivial-features errored at load with "Sorry, your Lisp is not
supported." This registers `:dotcl` in the guard and the component list, and adds
`src/tf-dotcl.lisp`.

### Load-time probes, as in the ABCL backend

Every decision is made at load time by querying the running CLR, never with
read-time `#+`/`#-`. dotcl has a reason of its own to insist on that: absent
ReadyToRun compilation its FASLs are portable IL, so one produced on x86-64
Windows can be loaded on arm64 Linux. A feature frozen by the reader would
travel with the FASL and be wrong on arrival.

The three CLR probes sit behind a marked seam - `BitConverter.IsLittleEndian`
for endianness, `RuntimeInformation.IsOSPlatform` and `.ProcessArchitecture` for
OS and CPU - with the normalization to this library's contract kept separate
from them.

### Bitness is left to the implementation

dotcl pushes `:32-bit` / `:64-bit` itself, from `IntPtr.Size`, which is the
width the contract is about: it is what CFFI reads to size a pointer.

Deriving it from `most-positive-fixnum` - portable, and right on implementations
whose fixnum tracks the pointer - is wrong here. dotcl's fixnum is a .NET
`Int64` however wide the pointer is, so the test always answers 64. On a 32-bit
target that lands `:64-BIT` beside the `:32-BIT` already pushed, and `pushnew`
cannot take the other one back. Measured on browser-wasm, where the pointer is
four bytes:

```
dotcl pushes            (:32-BIT)
the derivation says      :64-BIT
most-positive-fixnum     9223372036854775807
```

Desktop never showed it: there both answers are 64 and `pushnew` dedupes.

### Architectures without a name

The CPU probe stays silent for the architectures .NET names and portable Lisp
does not - `Wasm`, `S390x`, `LoongArch64`, `Ppc64le`, `RiscV64`. None appears in
any backend in `src/`. Silence seemed better than a keyword nobody reads, and
the probe is where a name would go if this library settles on one.

### Tests

`trivial-features-tests` on dotcl 0.1.23, Windows arm64: 9 of 10.

`CPU.2` fails inside the test's own `GetSystemInfo` grovel - `12` (ARM64) is not
a value of its `FOREIGN-ENUM ARCHITECTURE`, which predates Windows on ARM - and
is unrelated to this backend.
